### PR TITLE
Make the go template accept files as input

### DIFF
--- a/tool/templates/template.go
+++ b/tool/templates/template.go
@@ -15,11 +15,11 @@ func main() {
 	// Uncomment this line to disable garbage collection
 	// debug.SetGCPercent(-1)
 
-	argsWithProg := os.Args
 	var input []byte
 	var err error
-	if len(argsWithProg) > 1 {
-		input,err = ioutil.ReadFile(argsWithProg[1])
+	if len(os.Args) > 1 {
+		// Read input from file for local debugging
+		input, err = ioutil.ReadFile(os.Args[1])
 		if err != nil {
 			panic(err)
 		}

--- a/tool/templates/template.go
+++ b/tool/templates/template.go
@@ -15,10 +15,20 @@ func main() {
 	// Uncomment this line to disable garbage collection
 	// debug.SetGCPercent(-1)
 
-	// Read input from stdin
-	input, err := ioutil.ReadAll(os.Stdin)
-	if err != nil {
-		panic(err)
+	argsWithProg := os.Args
+	var input []byte
+	var err error
+	if len(argsWithProg) > 1 {
+		input,err = ioutil.ReadFile(argsWithProg[1])
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		// Read input from stdin
+		input, err = ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	// Start resolution


### PR DESCRIPTION
Change the go template such that one can pass the input file path as argument.

The goal is to make it easier to launch it from Goland.