### PR TITLE
Properly raise Exceptions when executable isn't found

### DIFF
--- a/tool/runners/bash.py
+++ b/tool/runners/bash.py
@@ -3,6 +3,7 @@ import os
 import stat
 import subprocess
 
+from tool.runners.exceptions import CompilationError, RuntimeError
 from tool.runners.wrapper import SubmissionWrapper
 
 
@@ -21,7 +22,7 @@ class SubmissionBash(SubmissionWrapper):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 # executable not found
-                return None
+                raise CompilationError(e)
             else:
                 # subprocess exited with another error
-                return None
+                raise RuntimeError(e)

--- a/tool/runners/deno.py
+++ b/tool/runners/deno.py
@@ -1,6 +1,7 @@
 import errno
 import subprocess
 
+from tool.runners.exceptions import CompilationError, RuntimeError
 from tool.runners.wrapper import SubmissionWrapper
 
 
@@ -18,10 +19,10 @@ class SubmissionDeno(SubmissionWrapper):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 # executable not found
-                return None
+                raise CompilationError(e)
             else:
                 # subprocess exited with another error
-                return None
+                raise RuntimeError(e)
 
     def __call__(self):
         return SubmissionDeno(self.file)

--- a/tool/runners/deno_ts.py
+++ b/tool/runners/deno_ts.py
@@ -1,6 +1,7 @@
 import errno
 import subprocess
 
+from tool.runners.exceptions import CompilationError, RuntimeError
 from tool.runners.wrapper import SubmissionWrapper
 
 
@@ -18,10 +19,10 @@ class SubmissionDenoTS(SubmissionWrapper):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 # executable not found
-                return None
+                raise CompilationError(e)
             else:
                 # subprocess exited with another error
-                return None
+                raise RuntimeError(e)
 
     def __call__(self):
         return SubmissionDenoTS(self.file)

--- a/tool/runners/julia.py
+++ b/tool/runners/julia.py
@@ -1,6 +1,7 @@
 import errno
 import subprocess
 
+from tool.runners.exceptions import CompilationError, RuntimeError
 from tool.runners.wrapper import SubmissionWrapper
 
 
@@ -18,10 +19,10 @@ class SubmissionJulia(SubmissionWrapper):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 # executable not found
-                return None
+                raise CompilationError(e)
             else:
                 # subprocess exited with another error
-                return None
+                raise RuntimeError(e)
         except subprocess.CalledProcessError as e:
             print(e.output.decode())
 

--- a/tool/runners/nim.py
+++ b/tool/runners/nim.py
@@ -2,7 +2,7 @@ import errno
 import tempfile
 import subprocess
 
-from tool.runners.exceptions import CompilationError
+from tool.runners.exceptions import CompilationError, RuntimeError
 from tool.runners.wrapper import SubmissionWrapper
 
 
@@ -36,7 +36,7 @@ class SubmissionNim(SubmissionWrapper):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 # executable not found
-                return None
+                raise CompilationError(e)
             else:
                 # subprocess exited with another error
-                return None
+                raise RuntimeError(e)

--- a/tool/runners/node.py
+++ b/tool/runners/node.py
@@ -1,6 +1,7 @@
 import errno
 import subprocess
 
+from tool.runners.exceptions import CompilationError, RuntimeError
 from tool.runners.wrapper import SubmissionWrapper
 
 
@@ -18,10 +19,10 @@ class SubmissionNode(SubmissionWrapper):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 # executable not found
-                return None
+                raise CompilationError(e)
             else:
                 # subprocess exited with another error
-                return None
+                raise RuntimeError(e)
 
     def __call__(self):
         return SubmissionNode(self.file)

--- a/tool/runners/php.py
+++ b/tool/runners/php.py
@@ -1,6 +1,7 @@
 import errno
 import subprocess
 
+from tool.runners.exceptions import CompilationError, RuntimeError
 from tool.runners.wrapper import SubmissionWrapper
 
 
@@ -18,10 +19,10 @@ class SubmissionPHP(SubmissionWrapper):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 # executable not found
-                return None
+                raise CompilationError(e)
             else:
                 # subprocess exited with another error
-                return None
+                raise RuntimeError(e)
 
     def __call__(self):
         return SubmissionPHP(self.file)

--- a/tool/runners/ruby.py
+++ b/tool/runners/ruby.py
@@ -1,6 +1,7 @@
 import errno
 import subprocess
 
+from tool.runners.exceptions import CompilationError, RuntimeError
 from tool.runners.wrapper import SubmissionWrapper
 
 
@@ -18,10 +19,10 @@ class SubmissionRb(SubmissionWrapper):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 # executable not found
-                return None
+                raise CompilationError(e)
             else:
                 # subprocess exited with another error
-                return None
+                raise RuntimeError(e)
 
     def __call__(self):
         return SubmissionRb(self.file)


### PR DESCRIPTION
## Fixes
- Replaces all `return None` in wrappers with raising the proper Exception. This enables us to actually see the issue instead of crashing at the wrapper level.

Example:
```bash
# Before
./aoc run -fnt -d2
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Running submissions for day 02:

* part 1:
Traceback (most recent call last):
  File "/home/lithium/Documents/adventofcode-2021/./aoc", line 6, in <module>
    AOC()
  File "/home/lithium/Documents/adventofcode-2021/tool/AOC.py", line 43, in __init__
    getattr(self, args.command)(sys.argv[2:])
  File "/home/lithium/Documents/adventofcode-2021/tool/AOC.py", line 107, in run
    run(
  File "/home/lithium/Documents/adventofcode-2021/tool/run.py", line 64, in run
    result = run_submission(
  File "/home/lithium/Documents/adventofcode-2021/tool/run.py", line 95, in run_submission
    output = submission.runnable.run(input.content)
  File "/home/lithium/Documents/adventofcode-2021/tool/runners/wrapper.py", line 19, in run
    lines = stdout.split("\n")[:-1]
AttributeError: 'NoneType' object has no attribute 'split'

# After
./aoc run -fnt -d2
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Running submissions for day 02:

* part 1:
Traceback (most recent call last):
  File "/home/lithium/Documents/adventofcode-2021/tool/runners/php.py", line 18, in exec
    return subprocess.check_output(["php", self.file, input]).decode()
  File "/home/lithium/.pyenv/versions/3.9.6/lib/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/home/lithium/.pyenv/versions/3.9.6/lib/python3.9/subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/home/lithium/.pyenv/versions/3.9.6/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/home/lithium/.pyenv/versions/3.9.6/lib/python3.9/subprocess.py", line 1821, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'php'
```

This is kind of an edge case (running `-f` with a runner's binary target missing) though.